### PR TITLE
provider/azurerm: make azurerm_simple_lb frontend_private_ip_address computed

### DIFF
--- a/builtin/providers/azurerm/resource_arm_simple_lb.go
+++ b/builtin/providers/azurerm/resource_arm_simple_lb.go
@@ -63,6 +63,7 @@ func resourceArmSimpleLb() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 			"frontend_allocation_method": &schema.Schema{
 				Type:         schema.TypeString,


### PR DESCRIPTION
As reported on Hashicorp/terraform#6429 when the frontend_private_ip_address is assigned dynamically, subsequent plan/apply operations incorrectly taint the resource.

Adding the Computed property to the schema object resolves the issue.
