### PR TITLE
Schema casing fix and general naming cleanup

### DIFF
--- a/builtin/providers/azurerm/resource_arm_simple_lb.go
+++ b/builtin/providers/azurerm/resource_arm_simple_lb.go
@@ -70,6 +70,9 @@ func resourceArmSimpleLb() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validateAllocationMethod,
 				ForceNew:     true,
+				StateFunc: func(id interface{}) string {
+					return strings.ToLower(id.(string))
+				},
 			},
 			"frontend_subnet": &schema.Schema{
 				Type:     schema.TypeString,
@@ -462,7 +465,7 @@ func flattenAzureRmFrontendIp(frontenIpArray []network.FrontendIPConfiguration, 
 	if frontenIp.Properties.PrivateIPAddress != nil {
 		d.Set("frontend_private_ip_address", *frontenIp.Properties.PrivateIPAddress)
 	}
-	d.Set("frontend_allocation_method", string(frontenIp.Properties.PrivateIPAllocationMethod))
+	d.Set("frontend_allocation_method", strings.ToLower(string(frontenIp.Properties.PrivateIPAllocationMethod)))
 	if frontenIp.Properties.Subnet != nil {
 		d.Set("frontend_subnet", *frontenIp.Properties.Subnet.ID)
 	}

--- a/builtin/providers/azurerm/resource_arm_simple_lb.go
+++ b/builtin/providers/azurerm/resource_arm_simple_lb.go
@@ -332,40 +332,40 @@ func pullOutFrontEndIps(d *schema.ResourceData) (*[]network.FrontendIPConfigurat
 
 	returnRules := []network.FrontendIPConfiguration{}
 
-	frontedIpName := fmt.Sprintf("%sfrontendip", d.Get("name").(string))
-	frontedIpAllocationMethod := network.IPAllocationMethod(d.Get("frontend_allocation_method").(string))
-	frontedIpSubnet := d.Get("frontend_subnet").(string)
-	frontedIpPublicIpAddress := d.Get("frontend_public_ip_address").(string)
-	frontedIpPrivateIpAddress := d.Get("frontend_private_ip_address").(string)
+	frontendIpName := fmt.Sprintf("%sfrontendip", d.Get("name").(string))
+	frontendIpAllocationMethod := network.IPAllocationMethod(d.Get("frontend_allocation_method").(string))
+	frontendIpSubnet := d.Get("frontend_subnet").(string)
+	frontendIpPublicIpAddress := d.Get("frontend_public_ip_address").(string)
+	frontendIpPrivateIpAddress := d.Get("frontend_private_ip_address").(string)
 
-	if frontedIpSubnet == "" && frontedIpPublicIpAddress == "" {
+	if frontendIpSubnet == "" && frontendIpPublicIpAddress == "" {
 		var logMsg = fmt.Sprintf("[ERROR] Either a subnet of a public ip address must be provided")
 		log.Printf("[resourceArmSimpleLb] %s", logMsg)
 		return nil, fmt.Errorf(logMsg)
 	}
 
-	if frontedIpPrivateIpAddress == "" && frontedIpAllocationMethod == network.Static {
+	if frontendIpPrivateIpAddress == "" && frontendIpAllocationMethod == network.Static {
 		var logMsg = fmt.Sprintf("An private IP address must be provided if static allocation is used.")
 		log.Printf("[resourceArmSimpleLb] %s", logMsg)
 		return nil, fmt.Errorf(logMsg)
 	}
 
 	ipProps := network.FrontendIPConfigurationPropertiesFormat{
-		PrivateIPAllocationMethod: frontedIpAllocationMethod}
+		PrivateIPAllocationMethod: frontendIpAllocationMethod}
 
-	if frontedIpSubnet != "" {
-		subnet := network.Subnet{ID: &frontedIpSubnet}
+	if frontendIpSubnet != "" {
+		subnet := network.Subnet{ID: &frontendIpSubnet}
 		ipProps.Subnet = &subnet
 	}
-	if frontedIpPublicIpAddress != "" {
-		pubIp := network.PublicIPAddress{ID: &frontedIpPublicIpAddress}
+	if frontendIpPublicIpAddress != "" {
+		pubIp := network.PublicIPAddress{ID: &frontendIpPublicIpAddress}
 		ipProps.PublicIPAddress = &pubIp
 	}
-	if frontedIpPrivateIpAddress != "" {
-		ipProps.PrivateIPAddress = &frontedIpPrivateIpAddress
+	if frontendIpPrivateIpAddress != "" {
+		ipProps.PrivateIPAddress = &frontendIpPrivateIpAddress
 	}
 
-	frontendIpConf := network.FrontendIPConfiguration{Name: &frontedIpName, Properties: &ipProps}
+	frontendIpConf := network.FrontendIPConfiguration{Name: &frontendIpName, Properties: &ipProps}
 	returnRules = append(returnRules, frontendIpConf)
 	return &returnRules, nil
 }
@@ -402,10 +402,10 @@ func resourceArmSimpleLbCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	loadBalancer.Properties.Probes = probes
 
-	new_backend_pool_name := fmt.Sprintf("%sbackendpool", name)
-	backendpool := network.BackendAddressPool{Name: &new_backend_pool_name}
+	newBackendPoolName := fmt.Sprintf("%sbackendpool", name)
+	backendPool := network.BackendAddressPool{Name: &newBackendPoolName}
 	backendPoolConfs := []network.BackendAddressPool{}
-	backendPoolConfs = append(backendPoolConfs, backendpool)
+	backendPoolConfs = append(backendPoolConfs, backendPool)
 	loadBalancer.Properties.BackendAddressPools = &backendPoolConfs
 	loadBalancer.Properties.LoadBalancingRules = &[]network.LoadBalancingRule{}
 
@@ -449,28 +449,28 @@ func resourceArmSimpleLbCreate(d *schema.ResourceData, meta interface{}) error {
 	return flattenAllOfLb(respLb, d, meta)
 }
 
-func flattenAzureRmFrontendIp(frontenIpArray []network.FrontendIPConfiguration, d *schema.ResourceData) error {
+func flattenAzureRmFrontendIp(frontendIpArray []network.FrontendIPConfiguration, d *schema.ResourceData) error {
 	log.Printf("[resourceArmSimpleLb] flattenAzureRmFrontendIp[enter]")
 	defer log.Printf("[resourceArmSimpleLb] flattenAzureRmFrontendIp[exit]")
 
-	if len(frontenIpArray) < 1 {
+	if len(frontendIpArray) < 1 {
 		return nil
 	}
-	if len(frontenIpArray) > 1 {
+	if len(frontendIpArray) > 1 {
 		log.Printf("[WARN] More than 1 frontend ip was found.  The simpleLB resource will just use the first one.")
 	}
 
-	frontenIp := frontenIpArray[0]
+	frontendIp := frontendIpArray[0]
 
-	if frontenIp.Properties.PrivateIPAddress != nil {
-		d.Set("frontend_private_ip_address", *frontenIp.Properties.PrivateIPAddress)
+	if frontendIp.Properties.PrivateIPAddress != nil {
+		d.Set("frontend_private_ip_address", *frontendIp.Properties.PrivateIPAddress)
 	}
-	d.Set("frontend_allocation_method", strings.ToLower(string(frontenIp.Properties.PrivateIPAllocationMethod)))
-	if frontenIp.Properties.Subnet != nil {
-		d.Set("frontend_subnet", *frontenIp.Properties.Subnet.ID)
+	d.Set("frontend_allocation_method", strings.ToLower(string(frontendIp.Properties.PrivateIPAllocationMethod)))
+	if frontendIp.Properties.Subnet != nil {
+		d.Set("frontend_subnet", *frontendIp.Properties.Subnet.ID)
 	}
-	if frontenIp.Properties.PublicIPAddress != nil {
-		d.Set("frontend_public_ip_address", *frontenIp.Properties.PublicIPAddress.ID)
+	if frontendIp.Properties.PublicIPAddress != nil {
+		d.Set("frontend_public_ip_address", *frontendIp.Properties.PublicIPAddress.ID)
 	}
 
 	return nil
@@ -570,10 +570,10 @@ func resourceArmSimpleLbUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 	loadBalancer.Properties.Probes = probes
 
-	new_backend_pool_name := fmt.Sprintf("%sbackendpool", name)
-	backendpool := network.BackendAddressPool{Name: &new_backend_pool_name}
+	newBackendPoolName := fmt.Sprintf("%sbackendpool", name)
+	backendPool := network.BackendAddressPool{Name: &newBackendPoolName}
 	backendPoolConfs := []network.BackendAddressPool{}
-	backendPoolConfs = append(backendPoolConfs, backendpool)
+	backendPoolConfs = append(backendPoolConfs, backendPool)
 	loadBalancer.Properties.BackendAddressPools = &backendPoolConfs
 	loadBalancer.Properties.LoadBalancingRules = &[]network.LoadBalancingRule{}
 
@@ -684,7 +684,7 @@ func flattenAllOfLb(loadBalancer network.LoadBalancer, d *schema.ResourceData, m
 	}
 	d.Set("backend_pool_id", (*loadBalancer.Properties.BackendAddressPools)[0].ID)
 	if loadBalancer.Properties.FrontendIPConfigurations == nil || len(*loadBalancer.Properties.FrontendIPConfigurations) != 1 {
-		return fmt.Errorf("There must be exactly 1 fronted to use this resource")
+		return fmt.Errorf("There must be exactly 1 frontend to use this resource")
 	}
 	d.Set("frontend_id", (*loadBalancer.Properties.FrontendIPConfigurations)[0].ID)
 	err = flattenAzureRmLoadBalancerRules(loadBalancer, d)

--- a/builtin/providers/azurerm/resource_arm_simple_lb_test.go
+++ b/builtin/providers/azurerm/resource_arm_simple_lb_test.go
@@ -12,22 +12,22 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccARMSimpleLB_basic(t *testing.T) {
+func TestAccAzureRMSimpleLB_basic(t *testing.T) {
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureSimpleLB_basic, ri, ri, ri)
+	config := fmt.Sprintf(testAccAzureRMSimpleLB_basic, ri, ri, ri)
 
 	justBeThere := regexp.MustCompile(".*")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckARMSimpleRMLBDestroy,
+		CheckDestroy: testCheckAzureRMSimpleRMLBDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckARMSimpleLBExists("azurerm_simple_lb.test"),
+					testCheckAzureRMSimpleLBExists("azurerm_simple_lb.test"),
 					resource.TestMatchResourceAttr("azurerm_simple_lb.test", "frontend_id", justBeThere),
 					resource.TestMatchResourceAttr("azurerm_simple_lb.test", "backend_pool_id", justBeThere),
 				),
@@ -36,21 +36,21 @@ func TestAccARMSimpleLB_basic(t *testing.T) {
 	})
 }
 
-func TestAccARMSimpleLB_updateTag(t *testing.T) {
+func TestAccAzureRMSimpleLB_updateTag(t *testing.T) {
 
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureSimpleLB_tags, ri, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureSimpleLB_updateTags, ri, ri, ri)
+	preConfig := fmt.Sprintf(testAccAzureRMSimpleLB_tags, ri, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMSimpleLB_updateTags, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckARMSimpleRMLBDestroy,
+		CheckDestroy: testCheckAzureRMSimpleRMLBDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckARMSimpleLBExists("azurerm_simple_lb.test"),
+					testCheckAzureRMSimpleLBExists("azurerm_simple_lb.test"),
 					resource.TestCheckResourceAttr(
 						"azurerm_simple_lb.test", "tags.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -63,7 +63,7 @@ func TestAccARMSimpleLB_updateTag(t *testing.T) {
 			resource.TestStep{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckARMSimpleLBExists("azurerm_simple_lb.test"),
+					testCheckAzureRMSimpleLBExists("azurerm_simple_lb.test"),
 					resource.TestCheckResourceAttr(
 						"azurerm_simple_lb.test", "tags.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -74,21 +74,21 @@ func TestAccARMSimpleLB_updateTag(t *testing.T) {
 	})
 }
 
-func TestAccARMSimpleLB_updateProbe(t *testing.T) {
+func TestAccAzureRMSimpleLB_updateProbe(t *testing.T) {
 
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureSimpleLB_probe, ri, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureSimpleLB_probeUpdate, ri, ri, ri)
+	preConfig := fmt.Sprintf(testAccAzureRMSimpleLB_probe, ri, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMSimpleLB_probeUpdate, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckARMSimpleRMLBDestroy,
+		CheckDestroy: testCheckAzureRMSimpleRMLBDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckARMSimpleLBExists("azurerm_simple_lb.test"),
+					testCheckAzureRMSimpleLBExists("azurerm_simple_lb.test"),
 					resource.TestCheckResourceAttr(
 						"azurerm_simple_lb.test", "probe.#", "2"),
 				),
@@ -97,7 +97,7 @@ func TestAccARMSimpleLB_updateProbe(t *testing.T) {
 			resource.TestStep{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckARMSimpleLBExists("azurerm_simple_lb.test"),
+					testCheckAzureRMSimpleLBExists("azurerm_simple_lb.test"),
 					resource.TestCheckResourceAttr(
 						"azurerm_simple_lb.test", "probe.#", "1"),
 				),
@@ -113,11 +113,11 @@ func TestAccAzureRMSimpleLB_dynamicFrontEndIPAddress(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckARMSimpleRMLBDestroy,
+		CheckDestroy: testCheckAzureRMSimpleRMLBDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
-				Check:  testCheckARMSimpleLBExists("azurerm_simple_lb.test"),
+				Check:  testCheckAzureRMSimpleLBExists("azurerm_simple_lb.test"),
 			},
 			{
 				Config: config,
@@ -128,7 +128,7 @@ func TestAccAzureRMSimpleLB_dynamicFrontEndIPAddress(t *testing.T) {
 	})
 }
 
-func testCheckARMSimpleLBExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSimpleLBExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
 		rs, ok := s.RootModule().Resources[name]
@@ -157,7 +157,7 @@ func testCheckARMSimpleLBExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testCheckARMSimpleRMLBDestroy(s *terraform.State) error {
+func testCheckAzureRMSimpleRMLBDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*ArmClient).loadBalancerClient
 
 	for _, rs := range s.RootModule().Resources {
@@ -182,7 +182,7 @@ func testCheckARMSimpleRMLBDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccAzureSimpleLB_basic = `
+var testAccAzureRMSimpleLB_basic = `
 resource "azurerm_resource_group" "test" {
     name = "acctestlbrg-%d"
     location = "West US"
@@ -221,7 +221,7 @@ resource "azurerm_simple_lb" "test" {
 }
 `
 
-var testAccAzureSimpleLB_tags = `
+var testAccAzureRMSimpleLB_tags = `
 resource "azurerm_resource_group" "test" {
     name = "acctestlbrg-%d"
     location = "West US"
@@ -265,7 +265,7 @@ resource "azurerm_simple_lb" "test" {
 }
 `
 
-var testAccAzureSimpleLB_updateTags = `
+var testAccAzureRMSimpleLB_updateTags = `
 resource "azurerm_resource_group" "test" {
     name = "acctestlbrg-%d"
     location = "West US"
@@ -308,7 +308,7 @@ resource "azurerm_simple_lb" "test" {
 }
 `
 
-var testAccAzureSimpleLB_probe = `
+var testAccAzureRMSimpleLB_probe = `
 resource "azurerm_resource_group" "test" {
     name = "acctestlbrg-%d"
     location = "West US"
@@ -363,7 +363,7 @@ resource "azurerm_simple_lb" "test" {
 }
 `
 
-var testAccAzureSimpleLB_probeUpdate = `
+var testAccAzureRMSimpleLB_probeUpdate = `
 resource "azurerm_resource_group" "test" {
     name = "acctestlbrg-%d"
     location = "West US"


### PR DESCRIPTION
Hi,

We found that the front_allocation_method value was being validated in a case insensitive manner but was being written to the state in the provided form. This meant that changing the value from `Dynamic` to `dynamic` would cause the resource to be recreated.

The second commit fixes typos and naming of variables in the resource code and brings the names of the exported test functions in line with the others in the azurerm package.

Two of the acceptance tests are still failing, I can look into these later if required:

```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMSimpleLB_ -timeout 120m
=== RUN   TestAccAzureRMSimpleLB_basic
--- PASS: TestAccAzureRMSimpleLB_basic (159.91s)
=== RUN   TestAccAzureRMSimpleLB_updateTag
--- FAIL: TestAccAzureRMSimpleLB_updateTag (139.26s)
    testing.go:264: Step 0 error: Check failed: Check 2/4 error: azurerm_simple_lb.test: Attribute 'tags.#' expected "2", got ""
=== RUN   TestAccAzureRMSimpleLB_updateProbe
--- FAIL: TestAccAzureRMSimpleLB_updateProbe (191.47s)
    testing.go:264: Step 1 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: azurerm_simple_lb.test
          rule.#:                            "0" => "1"
          rule.3317206372.backend_port:      "" => "22"
          rule.3317206372.frontend_port:     "" => "22"
          rule.3317206372.load_distribution: "" => "Default"
          rule.3317206372.name:              "" => "rule1"
          rule.3317206372.probe_name:        "" => "testProbe1"
          rule.3317206372.protocol:          "" => "Tcp"
          rule.3317206372.rule_id:           "" => "<computed>"

        STATE: <truncated>

=== RUN   TestAccAzureRMSimpleLB_dynamicFrontEndIPAddress
--- PASS: TestAccAzureRMSimpleLB_dynamicFrontEndIPAddress (246.28s)
FAIL
exit status 1
FAIL    github.com/hashicorp/terraform/builtin/providers/azurerm    737.025s
```
